### PR TITLE
pin platform version for now at 5.0.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,7 @@
 
 ;   Autor: Aaron Christophel ATCnetz.de
 [env:lolin32_lite]
-platform = espressif32
+platform = espressif32@5.0.0
 board = lolin32_lite
 framework = arduino
 upload_port = COM5


### PR DESCRIPTION
5.1.0 lead to constant reset cycles

logs of erros i have seen with 5.1.0 and that went away by pinning to 5.0.0
we may want to report this upstream but i am pretty new to this so not sure if i can be of help maybe @atc1441 should rather report it :) 
```
ets Jul 29 2019 12:21:46

rst:0xc (SW_CPU_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3fff0030,len:1184
load:0x40078000,len:13132
load:0x40080400,len:3036
entry 0x400805e4

assert failed: do_core_init startup.c:298 (flash_ret == ESP_OK)

Backtrace:0x400832ed:0x3ffe3aa00x40087155:0x3ffe3ac0 0x4008bc65:0x3ffe3ae0 0x400d58a2:0x3ffe3c10 0x40082a09:0x3ffe3c40 0x400792ba:0x3ffe3c90  |<-CORRUPTED

ELF file SHA256: 0000000000000000
```