### PR TITLE
Hardware SPI also on the Nano for improved upload speeds, added an option to save stock-mac to infoblock

### DIFF
--- a/Arduino-Nano_Flasher/src/main.cpp
+++ b/Arduino-Nano_Flasher/src/main.cpp
@@ -210,6 +210,7 @@ typedef enum {
     CMD_WRITE_SFR = 25,
     CMD_ERASE_FLASH = 26,
     CMD_ERASE_INFOBLOCK = 27,
+    CMD_SAVE_MAC_FROM_FW = 40,
 } ZBS_UART_PROTO;
 
 void dump_ram() {
@@ -224,7 +225,7 @@ void dump_ram() {
         char string[20] = {0};
         for (uint8_t low = 0; low < 0x10; low++) {
             uint8_t temp = zbs.read_ram((high << 4) | low);
-            if((temp >= 0x20)&&(temp<0x7F)) {
+            if ((temp >= 0x20) && (temp < 0x7F)) {
                 string[low] = (char)temp;
             } else {
                 string[low] = '.';
@@ -387,6 +388,81 @@ void handle_uart_cmd(uint8_t cmd, uint8_t *cmd_buff, uint8_t len) {
             zbs.erase_infoblock();
             temp_buff[0] = 1;
             send_uart_answer(cmd, temp_buff, 1);
+            break;
+        case CMD_SAVE_MAC_FROM_FW:
+            zbs.select_flash(0);
+            // get original mac (first few bytes) from stock firmware
+            temp_buff[0] = 0;
+            temp_buff[1] = 0;
+            bool validMac = true;
+            for (uint8_t c = 0; c < 6; c++) {
+                temp_buff[c + 2] = zbs.read_flash(0xFC06 + c);
+            }
+            // try to recognize device type by reading a part of the flash
+            temp = (uint8_t *)calloc(8, 1);
+            for (uint8_t c = 0; c < 8; c++) {
+                temp[c] = zbs.read_flash(0x08 + c);
+            }
+            const uint8_t val29[8] = {0x7d, 0x22, 0xff, 0x02, 0xa4, 0x58, 0xf0, 0x90};
+            const uint8_t val154[8] = {0xa1, 0x23, 0x22, 0x02, 0xa4, 0xc3, 0xe4, 0xf0};
+            if (memcmp(temp, val29, 8) == 0) {
+                // 2.9" 033
+                temp_buff[6] = 0x3B;
+                temp_buff[7] = 0x10;
+            } else if (memcmp(temp, val154, 8) == 0) {
+                // 1.54" 033
+                temp_buff[6] = 0x34;
+                temp_buff[7] = 0x10;
+            } else {
+                // not supported...
+                validMac = false;  // can't assume the mac we read makes any sense...
+                temp_buff[6] = 0xFF;
+                temp_buff[7] = 0xFF;
+            }
+            free(temp);
+            // calculate last nibble (checksum)
+            uint8_t xorchk = 0;
+            for (uint8_t c = 2; c < 8; c++) {
+                xorchk ^= (temp_buff[c] & 0x0F);
+                xorchk ^= (temp_buff[c] >> 4);
+            }
+            temp_buff[7] |= xorchk;
+
+            // check if there's already a mac in the infoblock
+            zbs.select_flash(1);  // select infoblock
+            bool infoblockEmpty = true;
+            for (uint8_t c = 0; c < 8; c++) {
+                uint8_t check = zbs.read_flash(0x10 + c);
+                if (check != 0xFF) infoblockEmpty = false;
+            }
+
+            if (infoblockEmpty && validMac) {
+                // succes!
+                for (uint8_t c = 0; c < 8; c++) {
+                    // write mac directly to infoblock without erasing; the bytes should all be 0xFF anyway
+                    zbs.write_flash(0x17 - c, temp_buff[c]);
+                }
+                temp_buff[0] = 1;
+                send_uart_answer(cmd, temp_buff, 1);
+            } else if (!infoblockEmpty) {
+                bool macAlreadyMatches = true;
+                for (uint8_t c = 0; c < 8; c++) {
+                    // check if the values match
+                    if (temp_buff[c] != zbs.read_flash(0x17 - c))
+                        macAlreadyMatches = false;
+                }
+                if (macAlreadyMatches) {
+                    temp_buff[0] = 1;
+                    send_uart_answer(cmd, temp_buff, 1);
+                } else {
+                    // fail
+                    temp_buff[0] = 0;
+                    send_uart_answer(cmd, temp_buff, 1);
+                }
+            } else {
+                temp_buff[0] = 0;
+                send_uart_answer(cmd, temp_buff, 1);
+            }
             break;
     }
 }

--- a/Arduino-Nano_Flasher/src/zbs_interface.cpp
+++ b/Arduino-Nano_Flasher/src/zbs_interface.cpp
@@ -200,36 +200,22 @@ void ZBS_interface::clear_screen(uint16_t time) {
 }
 
 void ZBS_interface::send_byte(uint8_t data) {
+    SPCR |= (1 << SPE) | (1 << MSTR) | (1 << SPR0);
     digitalWrite(_SS_PIN, LOW);
-    delayMicroseconds(1);  // was 5
-    for (int i = 0; i < 8; i++) {
-        if (data & 0x80)
-            digitalWrite(_MOSI_PIN, HIGH);
-        else
-            digitalWrite(_MOSI_PIN, LOW);
-        delayMicroseconds(ZBS_spi_delay);
-        digitalWrite(_CLK_PIN, HIGH);
-        delayMicroseconds(ZBS_spi_delay);
-        digitalWrite(_CLK_PIN, LOW);
-        data <<= 1;
-    }
+    SPDR = data;
+    while (!(SPSR & (1 << SPIF)))
+        ;
     digitalWrite(_SS_PIN, HIGH);
 }
 
 uint8_t ZBS_interface::read_byte() {
     uint8_t data = 0x00;
     digitalWrite(_SS_PIN, LOW);
-    delayMicroseconds(1);  // 5
-    for (int i = 0; i < 8; i++) {
-        data <<= 1;
-        if (digitalRead(_MISO_PIN))
-            data |= 1;
-        delayMicroseconds(ZBS_spi_delay);
-        digitalWrite(_CLK_PIN, HIGH);
-        delayMicroseconds(ZBS_spi_delay);
-        digitalWrite(_CLK_PIN, LOW);
-    }
+    SPDR = 0x00;
+    while (!(SPSR & (1 << SPIF)))
+        ;
     digitalWrite(_SS_PIN, HIGH);
+    data = SPDR;
     return data;
 }
 

--- a/ESP32_Flasher/src/main.cpp
+++ b/ESP32_Flasher/src/main.cpp
@@ -137,6 +137,7 @@ typedef enum
   CMD_WRITE_SFR = 25,
   CMD_ERASE_FLASH = 26,
   CMD_ERASE_INFOBLOCK = 27,
+  CMD_SAVE_MAC_FROM_FW = 40,
 } ZBS_UART_PROTO;
 
 uint8_t temp_buff[0x200] = {0};
@@ -256,6 +257,82 @@ void handle_uart_cmd(uint8_t cmd, uint8_t *cmd_buff, uint8_t len)
     zbs.erase_infoblock();
     temp_buff[0] = 1;
     send_uart_answer(cmd, temp_buff, 1);
+    break;
+  case CMD_SAVE_MAC_FROM_FW:
+    uint8_t* temp = nullptr;
+    zbs.select_flash(0);
+    // get original mac (first few bytes) from stock firmware
+    temp_buff[0] = 0;
+    temp_buff[1] = 0;
+    bool validMac = true;
+    for (uint8_t c = 0; c < 6; c++) {
+        temp_buff[c + 2] = zbs.read_flash(0xFC06 + c);
+    }
+    // try to recognize device type by reading a part of the flash
+    temp = (uint8_t *)calloc(8, 1);
+    for (uint8_t c = 0; c < 8; c++) {
+        temp[c] = zbs.read_flash(0x08 + c);
+    }
+    const uint8_t val29[8] = {0x7d, 0x22, 0xff, 0x02, 0xa4, 0x58, 0xf0, 0x90};
+    const uint8_t val154[8] = {0xa1, 0x23, 0x22, 0x02, 0xa4, 0xc3, 0xe4, 0xf0};
+    if (memcmp(temp, val29, 8) == 0) {
+        // 2.9" 033
+        temp_buff[6] = 0x3B;
+        temp_buff[7] = 0x10;
+    } else if (memcmp(temp, val154, 8) == 0) {
+        // 1.54" 033
+        temp_buff[6] = 0x34;
+        temp_buff[7] = 0x10;
+    } else {
+        // not supported...
+        validMac = false;  // can't assume the mac we read makes any sense...
+        temp_buff[6] = 0xFF;
+        temp_buff[7] = 0xFF;
+    }
+    free(temp);
+    // calculate last nibble (checksum)
+    uint8_t xorchk = 0;
+    for (uint8_t c = 2; c < 8; c++) {
+        xorchk ^= (temp_buff[c] & 0x0F);
+        xorchk ^= (temp_buff[c] >> 4);
+    }
+    temp_buff[7] |= xorchk;
+
+    // check if there's already a mac in the infoblock
+    zbs.select_flash(1);  // select infoblock
+    bool infoblockEmpty = true;
+    for (uint8_t c = 0; c < 8; c++) {
+        uint8_t check = zbs.read_flash(0x10 + c);
+        if (check != 0xFF) infoblockEmpty = false;
+    }
+
+    if (infoblockEmpty && validMac) {
+        // succes!
+        for (uint8_t c = 0; c < 8; c++) {
+            // write mac directly to infoblock without erasing; the bytes should all be 0xFF anyway
+            zbs.write_flash(0x17 - c, temp_buff[c]);
+        }
+        temp_buff[0] = 1;
+        send_uart_answer(cmd, temp_buff, 1);
+    } else if (!infoblockEmpty) {
+        bool macAlreadyMatches = true;
+        for (uint8_t c = 0; c < 8; c++) {
+            // check if the values match
+            if (temp_buff[c] != zbs.read_flash(0x17 - c))
+                macAlreadyMatches = false;
+        }
+        if (macAlreadyMatches) {
+            temp_buff[0] = 1;
+            send_uart_answer(cmd, temp_buff, 1);
+        } else {
+            // fail
+            temp_buff[0] = 0;
+            send_uart_answer(cmd, temp_buff, 1);
+        }
+    } else {
+        temp_buff[0] = 0;
+        send_uart_answer(cmd, temp_buff, 1);
+    }
     break;
   }
 }

--- a/zbs_flasher.py
+++ b/zbs_flasher.py
@@ -21,22 +21,27 @@ CMD_READ_SFR = 24
 CMD_WRITE_SFR = 25
 CMD_ERASE_FLASH = 26
 CMD_ERASE_INFOBLOCK = 27
+CMD_SAVE_MAC_FROM_FW = 40
 
-if(len(sys.argv) < 4):
-    print("Manual: COM1 read/readI file.bin, or COM1 write/writeI file.bin 0 or slow_spi baudrate(default 115200) ")
-    print("Example: COM1 read file.bin slow_spi 115200 <- will read flash to file.bin with slow SPI and 115200 baud")
-    print("Example: COM1 write file.bin <- will write file.bin to flash with fast SPI and default 115200 baud")
-    print("Not the right arguments but here are the... please wait...")
-    ports_list = "possible UART ports: "
-    for port in serial.tools.list_ports.comports():
-        ports_list += port.device + " "
-    print(ports_list)
-    exit()
-
-usedCom = sys.argv[1]  # "COM5"
-read_or_write = sys.argv[2]
-file = sys.argv[3]
-usedBaud = 115200 
+if((len(sys.argv)==3) and (sys.argv[2].lower() == "mac".lower())):
+    usedCom = sys.argv[1]  # "COM5"
+    read_or_write = sys.argv[2]
+else:
+    if (len(sys.argv) < 4):
+        print("Manual: COM1 read/readI file.bin, or COM1 write/writeI file.bin 0 or slow_spi baudrate(default 115200) ")
+        print("Example: COM1 read file.bin slow_spi 115200 <- will read flash to file.bin with slow SPI and 115200 baud")
+        print("Example: COM1 write file.bin <- will write file.bin to flash with fast SPI and default 115200 baud")
+        print("Not the right arguments but here are the... please wait...")
+        ports_list = "possible UART ports: "
+        for port in serial.tools.list_ports.comports():
+            ports_list += port.device + " "
+        print(ports_list)
+        exit()
+    usedCom = sys.argv[1]  # "COM5"
+    read_or_write = sys.argv[2]
+    file = sys.argv[3]
+    
+usedBaud = 115200
 
 spi_speed = 0
 if len(sys.argv) >= 5:
@@ -247,6 +252,15 @@ else:
 
 if zbs_init()[0] != 0:
     print("Some Error in init")
+    exit()
+
+if (read_or_write.lower() == 'mac'.lower()):
+    send_cmd(CMD_SAVE_MAC_FROM_FW, bytearray([]))
+    answer_array = uart_receive_handler()
+    if answer_array[2] == 1:
+        print("Saved MAC from stock FW to infoblock, ready to flash custom firmware")
+        exit()
+    print("Error saving mac from stock FW to infoblock")
     exit()
 
 if(read_or_write.lower() == 'read'.lower()):


### PR DESCRIPTION
Usage:
`python3 .\zbs_flasher.py COM14 mac
Using port: COM14
ZBS Flasher version: 16
Saved MAC from stock FW to infoblock, ready to flash custom firmware`

The mac-saver-feature -only- works on vanilla tags that have not been flashed yet. Logic runs on the flasher itself. Could also be implemented in python with minimal effort I guess, but I wanted it to be able to run standalone in the future.