### PR TITLE
Add configuration variable for image format

### DIFF
--- a/CC2531_station/epaper_station_websocket/station.py
+++ b/CC2531_station/epaper_station_websocket/station.py
@@ -24,6 +24,7 @@ PANID = [ int(panid.strip(), 16) for panid in os.environ.get("EPS_PANID", defaul
 CHANNEL = int(os.environ.get("EPS_CHANNEL", default="11"))
 IMAGE_DIR = os.environ.get("EPS_IMAGE_DIR", default="./input_img")
 IMAGE_WORKDIR = os.environ.get("EPS_IMAGE_WORKDIR", default="tmp/")
+IMAGE_FORMAT = os.environ.get("EPS_IMAGE_FORMAT", default="1bppR")
 
 CHECKIN_DELAY = int(os.environ.get("EPS_CHECKIN_DELAY", default="300000")) # 900s
 RETRY_DELAY = int(os.environ.get("EPS_RETRY_DELAY", default="1000")) # 1s
@@ -219,10 +220,10 @@ def prepare_image(client, compressionSupported):
 
     if not os.path.isfile(file_conv):
         if is_bmp:
-            bmp2grays.convertImage(1, "1bppR", filename, file_conv)
+            bmp2grays.convertImage(1, IMAGE_FORMAT, filename, file_conv)
         else:
             Image.open(filename).convert("RGB").save(os.path.join(IMAGE_WORKDIR, "tempConvert.bmp"))
-            bmp2grays.convertImage(1, "1bppR", os.path.join(IMAGE_WORKDIR, "tempConvert.bmp"), file_conv)
+            bmp2grays.convertImage(1, IMAGE_FORMAT, os.path.join(IMAGE_WORKDIR, "tempConvert.bmp"), file_conv)
             
         if compressionSupported == 1:
             file = open(file_conv,"rb")


### PR DESCRIPTION
As the "original" firmware by dmitry for the Solum tags allows grayscale images, I have added the configuration environment-variable which enables me to set it to, for example, `6clrPkdR`.

In the end, a proper implementation for different image formats based on the capabilities of the receiving device would be nicer, especially for heterogeneous price-tag households, but for simpler use-cases this should be enough.