### PR TITLE
Fix case sensitivity in image file loading

### DIFF
--- a/CC2531_station/epaper_station_websocket/online_viewer.html
+++ b/CC2531_station/epaper_station_websocket/online_viewer.html
@@ -193,7 +193,8 @@
 		if (rssi > 127) rssi -= 255;
 		content += " RSSI: " + rssi + "<br>";
 		content += "Temperature: " + parseInt(Number("0x" + data.substring(46,48)), 10) + "<br>";
-		content += "<img onerror=\"this.onerror=null; this.src='no_img.jpg'\" style='width: 128px; height: 128px; object-fit: contain' src='input_img/" + data.substring(0,16) + ".png?temp=" + Date.now() + "'>";
+        var url = data.substring(0, 16).toLowerCase();
+		content += "<img onerror=\"this.onerror=null; this.src='no_img.jpg'\" style='width: 128px; height: 128px; object-fit: contain' src='input_img/" + url + ".png?temp=" + Date.now() + "'>";
 		return content;
 	}
 

--- a/CC2531_station/epaper_station_websocket/online_viewer.html
+++ b/CC2531_station/epaper_station_websocket/online_viewer.html
@@ -193,7 +193,7 @@
 		if (rssi > 127) rssi -= 255;
 		content += " RSSI: " + rssi + "<br>";
 		content += "Temperature: " + parseInt(Number("0x" + data.substring(46,48)), 10) + "<br>";
-        var url = data.substring(0, 16).toLowerCase();
+        	var url = data.substring(0, 16).toLowerCase();
 		content += "<img onerror=\"this.onerror=null; this.src='no_img.jpg'\" style='width: 128px; height: 128px; object-fit: contain' src='input_img/" + url + ".png?temp=" + Date.now() + "'>";
 		return content;
 	}


### PR DESCRIPTION
Now this change might be debatable. The station.py looks for images with lowercase MAC-Addresses. The online viewer uses upper case macs. Thus, on a case sensitive file system, the image will not be found. With this implementation, lower case is the expected image name.